### PR TITLE
fix(FEC-13539): [Click 2 Action] | CTA Doesn't show when seeking backwards.

### DIFF
--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -3,7 +3,7 @@ const {PLAYER_SIZE} = ui.Components;
 
 import {FloatingItem, FloatingManager} from '@playkit-js/ui-managers';
 
-import {MessageData} from './types';
+import {MessageButtonData, MessageData} from './types';
 import {CallToActionOverlay, CallToActionPopup} from './components';
 
 const DESCRIPTION_LINES_SMALL = 2;
@@ -24,12 +24,32 @@ class CallToActionManager {
     this.floatingManager = floatingManager;
   }
 
-  private showPopup({title, description, buttons}: MessageData) {
+  private showPopup({
+    title,
+    description,
+    buttons,
+    onClose
+  }: {
+    title?: string;
+    description?: string;
+    buttons?: MessageButtonData[];
+    onClose?: () => void;
+  }) {
     this.popupInstance = this.floatingManager.add({
       label: 'Call To Action Popup',
       mode: 'Immediate',
       position: 'InteractiveArea',
-      renderContent: () => <CallToActionPopup title={title} description={description} buttons={buttons} onClose={() => this.hidePopup()} />
+      renderContent: () => (
+        <CallToActionPopup
+          title={title}
+          description={description}
+          buttons={buttons}
+          onClose={() => {
+            this.hidePopup();
+            onClose && onClose();
+          }}
+        />
+      )
     });
   }
 
@@ -38,7 +58,7 @@ class CallToActionManager {
     this.popupInstance = null;
   }
 
-  private showOverlay(message: MessageData, descriptionLines: number) {
+  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void) {
     if (!this.player.paused) {
       this.player.pause();
       this.playOnClose = true;
@@ -56,7 +76,10 @@ class CallToActionManager {
             description={description}
             buttons={buttons}
             onClick={(link: string) => this.onCallToActionButtonClick(link)}
-            onClose={() => this.onOverlayCloseClick()}
+            onClose={() => {
+              this.onOverlayCloseClick();
+              onClose && onClose();
+            }}
             descriptionLines={descriptionLines}
           />
         )
@@ -104,22 +127,14 @@ class CallToActionManager {
     }
   }
 
-  public isOverlayMessage(message: MessageData) {
-    return (
-      !message.showToast ||
-      this.store.getState().shell.playerSize === PLAYER_SIZE.EXTRA_SMALL ||
-      this.store.getState().shell.playerSize === PLAYER_SIZE.SMALL
-    );
-  }
-
-  public addMessage(message: MessageData, duration?: number) {
+  public addMessage({message, duration, onClose}: {message: MessageData; duration?: number; onClose: () => void}) {
     switch (this.store.getState().shell.playerSize) {
       case PLAYER_SIZE.TINY: {
         return;
       }
       case PLAYER_SIZE.EXTRA_SMALL:
       case PLAYER_SIZE.SMALL: {
-        this.showOverlay(message, DESCRIPTION_LINES_SMALL);
+        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose);
         this.hideMessageAfterDuration(duration);
         break;
       }
@@ -127,12 +142,12 @@ class CallToActionManager {
       case PLAYER_SIZE.LARGE:
       case PLAYER_SIZE.EXTRA_LARGE: {
         if (message.showToast) {
-          this.showPopup(message);
+          this.showPopup({...message, onClose});
           if (message.timing.showOnEnd) {
             this.hideMessageAfterDuration(duration);
           }
         } else {
-          this.showOverlay(message, DESCRIPTION_LINES_LARGE);
+          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose);
           this.hideMessageAfterDuration(duration);
         }
       }

--- a/src/types/message-data.ts
+++ b/src/types/message-data.ts
@@ -15,7 +15,7 @@ interface MessageData {
   showToast?: boolean;
   buttons?: MessageButtonData[];
   timing: {
-    showMessageOnSeek?: boolean;
+    redisplayMessage?: boolean;
     duration?: number;
     showOnStart?: boolean;
     showOnEnd?: boolean;


### PR DESCRIPTION
### Description of the Changes

Refactor message timing logic:

- Fix invalid messages filter logic
- Sort messages by message start time
- Hide messages by current time instead of timer unless it's an overlay message or we are at playback end
- Show message for remaining duration instead of always using full duration
- Handle seeked event: allow showing messages more than once depending on current time, if the user did not explicitly close them or if they have redisplayMessage set to true

Resolves FEC-13539

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
