### PR TITLE
fix(FEC-13581): [Click 2 Action] | CTA "Go to site" button remain focused after return to player page.

### DIFF
--- a/src/components/button-with-tooltip/button-with-tooltip.tsx
+++ b/src/components/button-with-tooltip/button-with-tooltip.tsx
@@ -11,6 +11,15 @@ const ButtonWithTooltip = ({type, label, onClick}: ButtonWithTooltipProps) => {
 
   const [isFinalized, setIsFinalized] = useState(false);
   const [showTooltip, setShowTooltip] = useState(true);
+  const onClickWrapper = () => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
+    if (onClick) {
+      onClick();
+    }
+  };
 
   useEffect(() => {
     if (!isFinalized && buttonRef) {
@@ -23,18 +32,18 @@ const ButtonWithTooltip = ({type, label, onClick}: ButtonWithTooltipProps) => {
 
   if (!isFinalized) {
     return (
-      <Button type={type} tooltip={{label}} onClick={onClick} setRef={(ref: HTMLButtonElement) => setButtonRef(ref)} disabled={false}>
+      <Button type={type} tooltip={{label}} onClick={onClickWrapper} setRef={(ref: HTMLButtonElement) => setButtonRef(ref)} disabled={false}>
         {label}
       </Button>
     );
   }
 
   return showTooltip ? (
-    <Button type={type} tooltip={{label}} onClick={onClick} disabled={false}>
+    <Button type={type} tooltip={{label}} onClick={onClickWrapper} disabled={false}>
       {label}
     </Button>
   ) : (
-    <Button type={type} onClick={onClick} disabled={false}>
+    <Button type={type} onClick={onClickWrapper} disabled={false}>
       {label}
     </Button>
   );


### PR DESCRIPTION
### Description of the Changes

Blur button after it is clicked to prevent it from staying focused after returning to the page.
Using activeElement because calling .blur() on the ref doesn't work.

Resolves FEC-13581

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
