### PR TITLE
Player v7 | CTA | The configuration of "showToast": true, doesnt work.

### DIFF
--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -15,20 +15,22 @@ class CallToActionManager {
   private store: any;
   private player: KalturaPlayer;
   private popupInstance: FloatingItem | null = null;
-  private floatingManager: FloatingManager;
   private hideMessageTimeout = -1;
   private playQueued = false;
 
-  constructor(player: KalturaPlayer, floatingManager: FloatingManager, eventManager: PlaykitUI.EventManager) {
+  constructor(player: KalturaPlayer, eventManager: PlaykitUI.EventManager) {
     this.player = player;
     this.store = ui.redux.useStore();
-    this.floatingManager = floatingManager;
     eventManager.listen(player, this.player.Event.Core.PLAYING, () => {
       this.playQueued = false;
       if (this.removeActiveOverlay) {
         this.player.pause();
       }
     });
+  }
+
+  private get floatingManager(): FloatingManager {
+    return (this.player.getService('floatingManager') as FloatingManager) || {};
   }
 
   private showPopup({

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -1,5 +1,4 @@
 import {BasePlugin, KalturaPlayer} from '@playkit-js/kaltura-player-js';
-import {FloatingManager} from '@playkit-js/ui-managers';
 import {CallToActionConfig, MessageData} from './types';
 import {CallToActionManager} from './call-to-action-manager';
 
@@ -21,15 +20,11 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
 
   constructor(name: string, player: KalturaPlayer, config: CallToActionConfig) {
     super(name, player, config);
-    this.callToActionManager = new CallToActionManager(player, this.floatingManager, this.eventManager);
+    this.callToActionManager = new CallToActionManager(player, this.eventManager);
   }
 
   static isValid() {
     return true;
-  }
-
-  private get floatingManager(): FloatingManager {
-    return (this.player.getService('floatingManager') as FloatingManager) || {};
   }
 
   protected loadMedia(): void {


### PR DESCRIPTION
### Description of the Changes

The reference to floatingManager was passed into the manager class inside the plugin constructor.
If ui managers plugin was not loaded before cta plugin, this caused an empty object to be passed.
The plugin would then throw an exception when trying to display a toast message.

Solution - Call the service directly from the manager class.

Resolves FEC-13639

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
