### PR TITLE
fix(FEC-13650): Player v7 | CTA | CTA doesn't show when seeking backwards for the second CTA.

### DIFF
--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -179,6 +179,8 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
+
+    this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({
       message,
       duration,

--- a/src/components/text-with-tooltip/text-with-tooltip.tsx
+++ b/src/components/text-with-tooltip/text-with-tooltip.tsx
@@ -12,7 +12,7 @@ const TextWithTooltip = ({text, numberOfLines}: {text: string; numberOfLines: nu
   const [isFinalized, setIsFinalized] = useState(false);
 
   useLayoutEffect(() => {
-    if (textRef?.current && comparisonTextRef?.current) {
+    if (!isFinalized && textRef?.current && comparisonTextRef?.current) {
       setIsFinalized(true);
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -22,7 +22,7 @@ const TextWithTooltip = ({text, numberOfLines}: {text: string; numberOfLines: nu
       const comparisonTextHeight = comparisonTextRef?.current?.getBoundingClientRect().height;
       setShowTooltip(textHeight < comparisonTextHeight);
     }
-  }, [isFinalized]);
+  });
 
   const textElement = (
     <div ref={textRef} style={{'-webkit-line-clamp': numberOfLines}} className={styles.text}>


### PR DESCRIPTION
### Description of the Changes
Because activeMessage variable was not cleared correctly, when having two messages, one with timeFromEnd, it was possible to get to a situation where a message wasn't shown twice after seek even though it should be, because of the condition in time update event handler

The fix is to clear activeMessage when hiding a message, and wait for video duration to be set before sorting messages (otherwise timeFromEnd messages would be incorrectly sorted)

Also added fixes for messages not being hidden when showing a new message, and sometimes showing with an incorrect text

Resolves FEC-13650, FEC-13660

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
