### PR TITLE
fix(FEC-13700): Call To Action - Overlay message with showOnStart true does not resume video playback when closed

### DIFF
--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -10,18 +10,24 @@ const DESCRIPTION_LINES_SMALL = 2;
 const DESCRIPTION_LINES_LARGE = 4;
 
 class CallToActionManager {
-  private playOnClose = false;
-  private removeActiveOverlay: null | (() => void) = null;
-  private store: any;
   private player: KalturaPlayer;
+  private eventManager: PlaykitUI.EventManager;
+  private store: any;
+
+  private removeActiveOverlay: null | (() => void) = null;
   private popupInstance: FloatingItem | null = null;
   private hideMessageTimeout = -1;
   private playQueued = false;
+  private playOnClose = false;
 
   constructor(player: KalturaPlayer, eventManager: PlaykitUI.EventManager) {
     this.player = player;
     this.store = ui.redux.useStore();
-    eventManager.listen(player, this.player.Event.Core.PLAYING, () => {
+    this.eventManager = eventManager;
+  }
+
+  public init() {
+    this.eventManager.listen(this.player, this.player.Event.Core.PLAYING, () => {
       this.playQueued = false;
       if (this.removeActiveOverlay) {
         this.player.pause();
@@ -176,6 +182,15 @@ class CallToActionManager {
       window.clearTimeout(this.hideMessageTimeout);
       this.hideMessageTimeout = -1;
     }
+  }
+
+  public reset() {
+    this.removeMessage();
+    this.removeActiveOverlay = null;
+    this.popupInstance = null;
+    this.hideMessageTimeout = -1;
+    this.playQueued = false;
+    this.playOnClose = false;
   }
 }
 

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -36,6 +36,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
     if (this.messages.length) {
       this.eventManager.listenOnce(this.player, this.player.Event.Core.FIRST_PLAYING, () => {
         this.sortMessages();
+        this.callToActionManager.init();
         this.eventManager.listen(this.player, this.player.Event.Core.TIME_UPDATE, () => this.onTimeUpdate());
         this.eventManager.listen(this.player, this.player.Event.Core.SEEKED, () => this.onSeeked());
       });
@@ -238,9 +239,11 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   }
 
   public reset() {
+    this.eventManager.removeAll();
+    this.callToActionManager.reset();
+
     this.activeMessage = null;
     this.activeMessageEndTime = -1;
-    this.callToActionManager.removeMessage();
     for (const message of this.messages) {
       message.wasShown = false;
       message.wasDismissed = false;


### PR DESCRIPTION
### Description of the Changes

Start showing messages after FIRST_PLAYING event, otherwise an overlay message can appear on playback start when player.paused is not yet set to false, and then the overlay won't unpause the player when it closes

Also improve validation of negative message duration

Resolves FEC-13700

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
