### PR TITLE
fix(FEC-13873): when duration is empty the overlay does not appear

### DIFF
--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -154,7 +154,10 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
             message.timing.showOnEnd === true ||
             message.timing.timeFromStart !== undefined ||
             message.timing.timeFromEnd !== undefined);
-        const durationValid = message.timing && (message.timing.duration === undefined || message.timing.duration > 0);
+        const durationValid =
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          message.timing && (message.timing.duration === undefined || message.timing.duration > 0 || message.timing.duration === '');
         const contentValid = message.description || message.title || message.buttons.length;
 
         return durationValid && timingValid && contentValid;


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when not checking or leaving empty "hide after" field in kmc, kmc is passing empty string as default instead of `undefined`, which causes the plugin to think the message duration is invalid.

**solution:**
as it was decided to currently fix from plugin side, also check for empty string as part of the duration validation.
**Note-** I have added `@ts-ignore` intentionally, instead of changing the type of `duration` to `number | string`, so we will not forget to fix it eventually from kmc side (pass undefined instead of empty string), as `duration` should not be a `string`.

Solves FEC-13873

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
