### PR TITLE
fix(A11Y-55): Screen Reader: Core Player: CTA Overlay dialog is not announced by screen reader

### DIFF
--- a/src/components/button-with-tooltip/button-with-tooltip.tsx
+++ b/src/components/button-with-tooltip/button-with-tooltip.tsx
@@ -3,10 +3,11 @@ import {Button, ButtonType} from '@playkit-js/common/dist/components/button';
 interface ButtonWithTooltipProps {
   type: ButtonType;
   label: string;
+  focusOnMount?: boolean;
   onClick: () => void;
 }
 
-const ButtonWithTooltip = ({type, label, onClick}: ButtonWithTooltipProps) => {
+const ButtonWithTooltip = ({type, label, focusOnMount, onClick}: ButtonWithTooltipProps) => {
   const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>();
 
   const [isFinalized, setIsFinalized] = useState(false);
@@ -39,11 +40,11 @@ const ButtonWithTooltip = ({type, label, onClick}: ButtonWithTooltipProps) => {
   }
 
   return showTooltip ? (
-    <Button type={type} tooltip={{label}} onClick={onClickWrapper} disabled={false}>
+    <Button tabIndex={0} key={'finalized'} type={type} tooltip={{label}} onClick={onClickWrapper} disabled={false} focusOnMount={focusOnMount}>
       {label}
     </Button>
   ) : (
-    <Button type={type} onClick={onClickWrapper} disabled={false}>
+    <Button tabIndex={0} key={'finalized'} type={type} onClick={onClickWrapper} disabled={false} focusOnMount={focusOnMount}>
       {label}
     </Button>
   );

--- a/src/components/call-to-action-buttons/call-to-action-buttons.tsx
+++ b/src/components/call-to-action-buttons/call-to-action-buttons.tsx
@@ -13,7 +13,7 @@ const CallToActionButtons = ({buttons, onClick}: {buttons: Array<MessageButtonDa
 
     return (
       <div className={`${styles.callToActionButtons}`}>
-        <ButtonWithTooltip type={buttonType} label={button.label} onClick={(): void => onClick(button)} />
+        <ButtonWithTooltip type={buttonType} label={button.label} onClick={(): void => onClick(button)} focusOnMount />
       </div>
     );
   }
@@ -24,7 +24,7 @@ const CallToActionButtons = ({buttons, onClick}: {buttons: Array<MessageButtonDa
 
   return (
     <div className={`${styles.callToActionButtons} ${styles.twoButtons}`}>
-      <ButtonWithTooltip type={button1Type} label={button1.label} onClick={(): void => onClick(button1)} />
+      <ButtonWithTooltip type={button1Type} label={button1.label} onClick={(): void => onClick(button1)} focusOnMount />
       <ButtonWithTooltip type={button2Type} label={button2.label} onClick={(): void => onClick(button2)} />
     </div>
   );

--- a/src/components/call-to-action-overlay/call-to-action-overlay.tsx
+++ b/src/components/call-to-action-overlay/call-to-action-overlay.tsx
@@ -57,7 +57,7 @@ const CallToActionOverlay = withText({closeLabel: 'overlay.close'})(
   connect(mapStateToProps)(
     ({title, description, buttons, onClose, onClick, closeLabel, descriptionLines, sizeClass}: CallToActionOverlayProps): any => {
       return (
-        <div data-testid="call-to-action-overlay" className={`${styles.callToActionOverlay} ${sizeClass}`}>
+        <div role="alert" data-testid="call-to-action-overlay" className={`${styles.callToActionOverlay} ${sizeClass}`}>
           <div className={styles.closeButton} data-testid="call-to-action-overlay-close-button">
             <Button
               onClick={onClose}

--- a/src/components/call-to-action-overlay/call-to-action-overlay.tsx
+++ b/src/components/call-to-action-overlay/call-to-action-overlay.tsx
@@ -10,6 +10,7 @@ import {CallToActionButtons} from '../call-to-action-buttons';
 
 import * as styles from './call-to-action-overlay.scss';
 import {MessageButtonData} from '../../types';
+import {FocusTrap} from '../focus-trap';
 
 interface CallToActionOverlayProps {
   title: string;
@@ -57,30 +58,34 @@ const CallToActionOverlay = withText({closeLabel: 'overlay.close'})(
   connect(mapStateToProps)(
     ({title, description, buttons, onClose, onClick, closeLabel, descriptionLines, sizeClass}: CallToActionOverlayProps): any => {
       return (
-        <div role="alert" data-testid="call-to-action-overlay" className={`${styles.callToActionOverlay} ${sizeClass}`}>
-          <div className={styles.closeButton} data-testid="call-to-action-overlay-close-button">
-            <Button
-              onClick={onClose}
-              type={ButtonType.borderless}
-              size={ButtonSize.medium}
-              tooltip={{label: closeLabel!}}
-              ariaLabel={closeLabel}
-              icon={'close'}
-            />
-          </div>
-          <div className={styles.content}>
-            <div className={styles.title}>
-              <TextWithTooltip text={title || ''} numberOfLines={1} />
+        <div role="alertdialog" data-testid="call-to-action-overlay" className={`${styles.callToActionOverlay} ${sizeClass}`}>
+          <FocusTrap active>
+            <div className={styles.closeButton} data-testid="call-to-action-overlay-close-button">
+              <Button
+                tabIndex={0}
+                onClick={onClose}
+                type={ButtonType.borderless}
+                size={ButtonSize.medium}
+                tooltip={{label: closeLabel!}}
+                ariaLabel={closeLabel}
+                icon={'close'}
+                focusOnMount={buttons.length === 0}
+              />
             </div>
+            <div className={styles.content}>
+              <div className={styles.title}>
+                <TextWithTooltip text={title || ''} numberOfLines={1} />
+              </div>
 
-            <div className={styles.description}>
-              <TextWithTooltip text={description || ''} numberOfLines={descriptionLines} />
-            </div>
+              <div className={styles.description}>
+                <TextWithTooltip text={description || ''} numberOfLines={descriptionLines} />
+              </div>
 
-            <div className={styles.buttonsContainer}>
-              <CallToActionButtons buttons={buttons} onClick={onClick} />
+              <div className={styles.buttonsContainer}>
+                <CallToActionButtons buttons={buttons} onClick={onClick} />
+              </div>
             </div>
-          </div>
+          </FocusTrap>
         </div>
       );
     }

--- a/src/components/focus-trap/focus-trap.tsx
+++ b/src/components/focus-trap/focus-trap.tsx
@@ -1,14 +1,18 @@
 import {ComponentChildren} from 'preact';
 import {useEffect, useRef, useCallback} from 'preact/hooks';
 
+import {ui} from '@playkit-js/kaltura-player-js';
+const {withEventManager} = ui.Event;
+
 interface FocusTrapProps {
   children: ComponentChildren;
   active: boolean;
+  eventManager: any;
 }
 
 const FOCUSABLE_ELEMENTS_QUERY = 'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
-const FocusTrap = ({children, active}: FocusTrapProps) => {
+const FocusTrap = withEventManager(({children, active, eventManager}: FocusTrapProps) => {
   const trapRef = useRef(null);
 
   const setupFocusTrap = useCallback(() => {
@@ -36,11 +40,8 @@ const FocusTrap = ({children, active}: FocusTrapProps) => {
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
+    eventManager?.unlisten(document, 'keydown', handleKeyDown);
+    eventManager?.listen(document, 'keydown', handleKeyDown);
   }, [active]);
 
   useEffect(() => {
@@ -68,6 +69,6 @@ const FocusTrap = ({children, active}: FocusTrapProps) => {
   }, [active, setupFocusTrap]);
 
   return <div ref={trapRef}>{children}</div>;
-};
+});
 
 export {FocusTrap};

--- a/src/components/focus-trap/focus-trap.tsx
+++ b/src/components/focus-trap/focus-trap.tsx
@@ -1,0 +1,73 @@
+import {ComponentChildren} from 'preact';
+import {useEffect, useRef, useCallback} from 'preact/hooks';
+
+interface FocusTrapProps {
+  children: ComponentChildren;
+  active: boolean;
+}
+
+const FOCUSABLE_ELEMENTS_QUERY = 'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const FocusTrap = ({children, active}: FocusTrapProps) => {
+  const trapRef = useRef(null);
+
+  const setupFocusTrap = useCallback(() => {
+    if (!active) return;
+
+    const trapElement = trapRef.current;
+    if (!trapElement) return;
+
+    const focusableElements = (trapElement as HTMLElement).querySelectorAll(FOCUSABLE_ELEMENTS_QUERY);
+
+    if (focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0] as HTMLElement;
+    const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+    const handleKeyDown = (e: any) => {
+      if (e.key === 'Tab') {
+        if (e.shiftKey && document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        } else if (!e.shiftKey && document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [active]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const observer = new MutationObserver(() => {
+      setupFocusTrap();
+    });
+
+    const trapElement = trapRef.current;
+    if (trapElement) {
+      observer.observe(trapElement, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    setupFocusTrap();
+
+    return () => {
+      if (trapElement) {
+        observer.disconnect();
+      }
+    };
+  }, [active, setupFocusTrap]);
+
+  return <div ref={trapRef}>{children}</div>;
+};
+
+export {FocusTrap};

--- a/src/components/focus-trap/index.ts
+++ b/src/components/focus-trap/index.ts
@@ -1,0 +1,1 @@
+export {FocusTrap} from './focus-trap';


### PR DESCRIPTION
### Description of the Changes

- Add role="alertdialog" to overlay so it would be announced when it appears
- Add focus handling on buttons (focus the first visible button)
- Add focus trap to the overlay

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
