### PR TITLE
FEC-14341: Metadata based CTAs - product analytics (player)

### DIFF
--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -82,7 +82,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Toast,
-        ctaSource: ctaSource
+        ctaSource
       })
     );
   }
@@ -122,7 +122,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Overlay,
-        ctaSource: ctaSource
+        ctaSource
       })
     );
   }

--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -54,13 +54,13 @@ class CallToActionManager {
     description,
     buttons,
     onClose,
-    ctaSource
+    isMetadataBased
   }: {
     title?: string;
     description?: string;
     buttons?: MessageButtonData[];
     onClose?: () => void;
-    ctaSource: 'metadata_based' | 'player_level';
+    isMetadataBased: boolean;
   }) {
     this.popupInstance = this.floatingManager.add({
       label: 'Call To Action Popup',
@@ -82,7 +82,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Toast,
-        ctaSource
+        isMetadataBased
       })
     );
   }
@@ -92,7 +92,7 @@ class CallToActionManager {
     this.popupInstance = null;
   }
 
-  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void, ctaSource?: 'metadata_based' | 'player_level') {
+  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void, isMetadataBased?: boolean) {
     if (!this.player.paused || this.playQueued) {
       this.player.pause();
       this.playOnClose = true;
@@ -122,7 +122,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Overlay,
-        ctaSource
+        isMetadataBased
       })
     );
   }
@@ -172,12 +172,12 @@ class CallToActionManager {
     message,
     duration,
     onClose,
-    ctaSource
+    isMetadataBased
   }: {
     message: MessageData;
     duration?: number;
     onClose: () => void;
-    ctaSource: 'metadata_based' | 'player_level';
+    isMetadataBased: boolean;
   }) {
     switch (this.store.getState().shell.playerSize) {
       case PLAYER_SIZE.TINY: {
@@ -185,7 +185,7 @@ class CallToActionManager {
       }
       case PLAYER_SIZE.EXTRA_SMALL:
       case PLAYER_SIZE.SMALL: {
-        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose, ctaSource);
+        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose, isMetadataBased);
         this.hideMessageAfterDuration(duration);
         break;
       }
@@ -193,12 +193,12 @@ class CallToActionManager {
       case PLAYER_SIZE.LARGE:
       case PLAYER_SIZE.EXTRA_LARGE: {
         if (message.showToast) {
-          this.showPopup({...message, onClose, ctaSource});
+          this.showPopup({...message, onClose, isMetadataBased});
           if (message.timing.showOnEnd) {
             this.hideMessageAfterDuration(duration);
           }
         } else {
-          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose, ctaSource);
+          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose, isMetadataBased);
           this.hideMessageAfterDuration(duration);
         }
       }

--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -54,13 +54,13 @@ class CallToActionManager {
     description,
     buttons,
     onClose,
-    source
+    ctaSource
   }: {
     title?: string;
     description?: string;
     buttons?: MessageButtonData[];
     onClose?: () => void;
-    source: 'metadata_based' | 'player_level';
+    ctaSource: 'metadata_based' | 'player_level';
   }) {
     this.popupInstance = this.floatingManager.add({
       label: 'Call To Action Popup',
@@ -82,7 +82,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Toast,
-        ctaSource: source
+        ctaSource: ctaSource
       })
     );
   }
@@ -92,7 +92,7 @@ class CallToActionManager {
     this.popupInstance = null;
   }
 
-  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void, source?: 'metadata_based' | 'player_level') {
+  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void, ctaSource?: 'metadata_based' | 'player_level') {
     if (!this.player.paused || this.playQueued) {
       this.player.pause();
       this.playOnClose = true;
@@ -122,7 +122,7 @@ class CallToActionManager {
     this.player.dispatchEvent(
       new FakeEvent(CallToActionEvents.CALL_TO_ACTION_DISPLAYED, {
         displayType: DisplayType.Overlay,
-        ctaSource: source
+        ctaSource: ctaSource
       })
     );
   }
@@ -172,12 +172,12 @@ class CallToActionManager {
     message,
     duration,
     onClose,
-    source
+    ctaSource
   }: {
     message: MessageData;
     duration?: number;
     onClose: () => void;
-    source: 'metadata_based' | 'player_level';
+    ctaSource: 'metadata_based' | 'player_level';
   }) {
     switch (this.store.getState().shell.playerSize) {
       case PLAYER_SIZE.TINY: {
@@ -185,7 +185,7 @@ class CallToActionManager {
       }
       case PLAYER_SIZE.EXTRA_SMALL:
       case PLAYER_SIZE.SMALL: {
-        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose, source);
+        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose, ctaSource);
         this.hideMessageAfterDuration(duration);
         break;
       }
@@ -193,12 +193,12 @@ class CallToActionManager {
       case PLAYER_SIZE.LARGE:
       case PLAYER_SIZE.EXTRA_LARGE: {
         if (message.showToast) {
-          this.showPopup({...message, onClose, source});
+          this.showPopup({...message, onClose, ctaSource});
           if (message.timing.showOnEnd) {
             this.hideMessageAfterDuration(duration);
           }
         } else {
-          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose, source);
+          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose, ctaSource);
           this.hideMessageAfterDuration(duration);
         }
       }

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -241,7 +241,12 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
-    const isMetadataBased = !!this.config.metadataMessages?.includes(message);
+    const isMetadataBased = !this.config.messages?.some(
+      (activeMsg: MessageData) =>
+        activeMsg.title === (message as MessageData)?.title &&
+        activeMsg.description === (message as MessageData)?.description &&
+        activeMsg.timing === (message as MessageData)?.timing
+    );
 
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -241,7 +241,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
-    const source = this.config.metadataMessages?.includes(message) ? 'metadata_based' : 'player_level';
+    const ctaSource = this.config.metadataMessages?.includes(message) ? 'metadata_based' : 'player_level';
 
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({
@@ -250,7 +250,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
       onClose: () => {
         message.wasDismissed = true;
       },
-      source
+      ctaSource
     });
   }
 

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -241,7 +241,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
-    const ctaSource = this.config.metadataMessages?.includes(message) ? 'metadata_based' : 'player_level';
+    const isMetadataBased = !!this.config.metadataMessages?.includes(message);
 
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({
@@ -250,7 +250,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
       onClose: () => {
         message.wasDismissed = true;
       },
-      ctaSource
+      isMetadataBased
     });
   }
 

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -241,6 +241,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
+    const source = this.config.metadataMessages?.includes(message) ? 'metadata_based' : 'player_level';
 
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({
@@ -248,7 +249,8 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
       duration,
       onClose: () => {
         message.wasDismissed = true;
-      }
+      },
+      source
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

Add whether the CTA is metadata based or player level in eventVar4 of CTA_displayed event.

- Inside 'showMessage' function added new boolean variable called 'isMetadataBased', checking if the active message includes inside 'config.metadataMessages'.  if message is included 'isMetadataBased' = true , if not 'isMetadataBased' = false.
- Added new field called 'isMetadataBased' to the payload of 'CALL_TO_ACTION_DISPLAYED' event when dispatching the event.

related PRs: 
https://github.com/kaltura/playkit-js-call-to-action/pull/36
https://github.com/kaltura/playkit-js-kava/pull/194

[FEC-14341](https://kaltura.atlassian.net/browse/FEC-14341)


[FEC-14341]: https://kaltura.atlassian.net/browse/FEC-14341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ