### PR TITLE
FEC-14341: Metadata based CTAs - product analytics (player)

### DIFF
--- a/src/call-to-action-manager.tsx
+++ b/src/call-to-action-manager.tsx
@@ -53,14 +53,14 @@ class CallToActionManager {
     title,
     description,
     buttons,
-    onClose,
-    isMetadataBased
+    isMetadataBased,
+    onClose
   }: {
     title?: string;
     description?: string;
     buttons?: MessageButtonData[];
+    isMetadataBased?: boolean;
     onClose?: () => void;
-    isMetadataBased: boolean;
   }) {
     this.popupInstance = this.floatingManager.add({
       label: 'Call To Action Popup',
@@ -92,13 +92,13 @@ class CallToActionManager {
     this.popupInstance = null;
   }
 
-  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void, isMetadataBased?: boolean) {
+  private showOverlay(message: MessageData, descriptionLines: number, onClose?: () => void) {
     if (!this.player.paused || this.playQueued) {
       this.player.pause();
       this.playOnClose = true;
     }
 
-    const {title, description, buttons} = message;
+    const {title, description, buttons, isMetadataBased} = message;
     this.setOverlay(
       this.player.ui.addComponent({
         label: 'callToActionOverlay',
@@ -168,24 +168,14 @@ class CallToActionManager {
     }
   }
 
-  public addMessage({
-    message,
-    duration,
-    onClose,
-    isMetadataBased
-  }: {
-    message: MessageData;
-    duration?: number;
-    onClose: () => void;
-    isMetadataBased: boolean;
-  }) {
+  public addMessage({message, duration, onClose}: {message: MessageData; duration?: number; onClose: () => void}) {
     switch (this.store.getState().shell.playerSize) {
       case PLAYER_SIZE.TINY: {
         return;
       }
       case PLAYER_SIZE.EXTRA_SMALL:
       case PLAYER_SIZE.SMALL: {
-        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose, isMetadataBased);
+        this.showOverlay(message, DESCRIPTION_LINES_SMALL, onClose);
         this.hideMessageAfterDuration(duration);
         break;
       }
@@ -193,12 +183,12 @@ class CallToActionManager {
       case PLAYER_SIZE.LARGE:
       case PLAYER_SIZE.EXTRA_LARGE: {
         if (message.showToast) {
-          this.showPopup({...message, onClose, isMetadataBased});
+          this.showPopup({...message, onClose});
           if (message.timing.showOnEnd) {
             this.hideMessageAfterDuration(duration);
           }
         } else {
-          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose, isMetadataBased);
+          this.showOverlay(message, DESCRIPTION_LINES_LARGE, onClose);
           this.hideMessageAfterDuration(duration);
         }
       }

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -26,10 +26,7 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
     this.callToActionManager = new CallToActionManager(player, this.eventManager);
 
     // set isMetadataBased to false by default in all messages
-    this.config.messages = this.config.messages.map(message => ({
-      ...message,
-      isMetadataBased: false
-    }));
+    this.config.messages.forEach(message => (message.isMetadataBased = false));
   }
 
   static isValid() {

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -8,7 +8,6 @@ import {XMLParser} from 'fast-xml-parser';
 interface MessageDataWithTracking extends MessageData {
   wasShown?: boolean;
   wasDismissed?: boolean;
-  isMetadataBased?: boolean;
 }
 
 class CallToAction extends BasePlugin<CallToActionConfig> {
@@ -25,6 +24,12 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   constructor(name: string, player: KalturaPlayer, config: CallToActionConfig) {
     super(name, player, config);
     this.callToActionManager = new CallToActionManager(player, this.eventManager);
+
+    // set isMetadataBased to false by default in all messages
+    this.config.messages = this.config.messages.map(message => ({
+      ...message,
+      isMetadataBased: false
+    }));
   }
 
   static isValid() {
@@ -241,7 +246,6 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   }
 
   private showMessage(message: MessageDataWithTracking, duration?: number) {
-    message.isMetadataBased = message.isMetadataBased === undefined ? false : message.isMetadataBased;
     this.activeMessage = message;
     message.wasShown = true;
     this.callToActionManager.removeMessage();

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -241,7 +241,12 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   private showMessage(message: MessageDataWithTracking, duration?: number) {
     this.activeMessage = message;
     message.wasShown = true;
-    const isMetadataBased = !!this.config.metadataMessages?.includes(message);
+    const isMetadataBased = !this.config.messages?.some(
+      (activeMsg: MessageData) =>
+        activeMsg.title === (message as MessageData)?.title &&
+        activeMsg.description === (message as MessageData)?.description &&
+        activeMsg.timing === (message as MessageData)?.timing
+    );
 
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({

--- a/src/call-to-action.tsx
+++ b/src/call-to-action.tsx
@@ -8,6 +8,7 @@ import {XMLParser} from 'fast-xml-parser';
 interface MessageDataWithTracking extends MessageData {
   wasShown?: boolean;
   wasDismissed?: boolean;
+  isMetadataBased?: boolean;
 }
 
 class CallToAction extends BasePlugin<CallToActionConfig> {
@@ -169,7 +170,8 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
                 label: '',
                 link: ''
               }
-        )
+        ),
+        isMetadataBased: true
       }));
     }
     return [];
@@ -239,23 +241,16 @@ class CallToAction extends BasePlugin<CallToActionConfig> {
   }
 
   private showMessage(message: MessageDataWithTracking, duration?: number) {
+    message.isMetadataBased = message.isMetadataBased === undefined ? false : message.isMetadataBased;
     this.activeMessage = message;
     message.wasShown = true;
-    const isMetadataBased = !this.config.messages?.some(
-      (activeMsg: MessageData) =>
-        activeMsg.title === (message as MessageData)?.title &&
-        activeMsg.description === (message as MessageData)?.description &&
-        activeMsg.timing === (message as MessageData)?.timing
-    );
-
     this.callToActionManager.removeMessage();
     this.callToActionManager.addMessage({
       message,
       duration,
       onClose: () => {
         message.wasDismissed = true;
-      },
-      isMetadataBased
+      }
     });
   }
 

--- a/src/types/message-data.ts
+++ b/src/types/message-data.ts
@@ -22,6 +22,7 @@ interface MessageData {
     timeFromStart?: number;
     timeFromEnd?: number;
   };
+  isMetadataBased?: boolean;
 }
 
 export {MessageData, MessageButtonData, MessageButtonType};


### PR DESCRIPTION
### Description of the Changes

Add whether the CTA is metadata based or player level in eventVar4 of CTA_displayed event.

- Added new boolean field called isMetadataBased.
- The constructor of 'call-to-action.tsx' sets 'isMetadataBased' to false by default in all messages
-  'isMetadataBased' sets to true only for 'metadataMessages' inside the function 'replaceMetadataFields' when updating the cta fields.

related PRs: 
[playkit-js-call-to-action/pull/36](https://github.com/kaltura/playkit-js-call-to-action/pull/36)
[playkit-js-kava/pull/194](https://github.com/kaltura/playkit-js-kava/pull/194)

[FEC-14341](https://kaltura.atlassian.net/browse/FEC-14341)


[FEC-14341]: https://kaltura.atlassian.net/browse/FEC-14341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ